### PR TITLE
change getRandomEmail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - "6"
+script:
+  - npm test
+  - npm run lint

--- a/index.js
+++ b/index.js
@@ -84,4 +84,14 @@ function getInbox(email) {
   return get(`${API_URL}/request/mail/id/${getEmailHash(email)}/format/json/`).then(JSON.parse);
 }
 
-module.exports = { generateEmail, getInbox };
+function deleteMail(mailId) {
+  return new Promise((resolve, reject) => {
+    if (!mailId) {
+      return reject('Please specify mail identifier');
+    }
+
+    return get(`${API_URL}/request/delete/id/${mailId}/format/json/`).then(JSON.parse);
+  });
+}
+
+module.exports = { generateEmail, getInbox, deleteMail };

--- a/index.js
+++ b/index.js
@@ -47,16 +47,13 @@ function getEmailHash(email) {
  * @param {string} prefix
  * @returns {string}
  */
-function getRandomEmail(domains, len, prefix) {
-  if(!len) { len = 7; }
-  if(!prefix) { prefix = ''; }
-  
+function getRandomEmail(domains, len = 7, prefix = '') {
   const alfabet = '1234567890abcdefghijklmnopqrstuvwxyz';
-  
-  let name = !prefix ? '' : prefix + '-';
-  
-  for(let i = 0; i < len; i++) {
-    let randomChar = Math.round(Math.random() * (alfabet.length - 1));
+
+  let name = !prefix ? '' : `${prefix}-`;
+
+  for (let i = 0; i < len; i++) {
+    const randomChar = Math.round(Math.random() * (alfabet.length - 1));
     name += alfabet.charAt(randomChar);
   }
 

--- a/index.js
+++ b/index.js
@@ -44,10 +44,22 @@ function getEmailHash(email) {
  * Generates random email in given domains
  * @param {Array} domains
  * @param {number} [len=7]
+ * @param {string} prefix
  * @returns {string}
  */
-function getRandomEmail(domains, len = 7) {
-  const name = Math.random().toString(36).substring(len);
+function getRandomEmail(domains, len, prefix) {
+  if(!len) { len = 7; }
+  if(!prefix) { prefix = ''; }
+  
+  const alfabet = '1234567890abcdefghijklmnopqrstuvwxyz';
+  
+  let name = !prefix ? '' : prefix + '-';
+  
+  for(let i = 0; i < len; i++) {
+    let randomChar = Math.round(Math.random() * (alfabet.length - 1));
+    name += alfabet.charAt(randomChar);
+  }
+
   const domain = domains[Math.floor(Math.random() * domains.length)];
 
   return name + domain;
@@ -64,11 +76,12 @@ function getAvailableDomains() {
 /**
  * Generates email on temp-mail.ru
  * @param {number} [len]
+ * @param {string} prefix
  * @returns {Promise.<String, Error>}
  */
-function generateEmail(len) {
+function generateEmail(len, prefix) {
   return getAvailableDomains()
-    .then(availableDomains => getRandomEmail(availableDomains, len));
+    .then(availableDomains => getRandomEmail(availableDomains, len, prefix));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "test": "node test/*.js | tap-spec",
-    "lint": "eslint index.js tests/*.js"
+    "lint": "eslint index.js \"tests/*.js\""
   },
   "author": {
     "name": "Ilnur Khalilov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "temp-mail",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Node.js API wrapper for temp-mail.ru",
   "main": "index.js",
   "repository": {
@@ -8,8 +8,8 @@
     "url": "git@github.com:xomyaq/tempmail.git"
   },
   "devDependencies": {
-    "eslint": "^2.10.0",
-    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint": "^3.2.2",
+    "eslint-config-airbnb-base": "^5.0.1",
     "eslint-plugin-import": "^1.8.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.1"
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "test": "node test/*.js | tap-spec",
-    "lint": "node ./node_modules/eslint/bin/eslint.js index.js tests/*.js"
+    "lint": "eslint index.js tests/*.js"
   },
   "author": {
     "name": "Ilnur Khalilov",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=6.0.0"
   },
   "scripts": {
-    "test": "node test/*.js | tap-spec",
+    "test": "node tests/*.js | tap-spec",
     "lint": "eslint index.js \"tests/*.js\""
   },
   "author": {

--- a/test/index.js
+++ b/test/index.js
@@ -16,3 +16,33 @@ test('Create a new email', (t) => {
       t.end();
     });
 });
+
+test('Generate email with prefix', (t) => {
+  // avoid http error 429
+  setTimeout(() => {
+    generateEmail(5, 'prefix')
+      .then((email) => {
+        const name = email.slice(0, email.indexOf('@'));
+        const prefix = name.slice(0, 6);
+
+        t.equal(name.length, 12, 'email name is correct');
+        t.equal(prefix, 'prefix', 'prefix is correct');
+
+        t.end();
+      });
+  }, 700);
+});
+
+test('Generate email without prefix', (t) => {
+  // avoid http error 429
+  setTimeout(() => {
+    generateEmail(5)
+      .then((email) => {
+        const name = email.slice(0, email.indexOf('@'));
+
+        t.equal(name.length, 5, 'email name is correct');
+
+        t.end();
+      });
+  }, 700);
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,4 +1,4 @@
-const test = require('tape');
+const test = require('tape'); // eslint-disable-line import/no-extraneous-dependencies
 const { generateEmail, getInbox } = require('../index');
 
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -16,3 +16,33 @@ test('Create a new email', (t) => {
       t.end();
     });
 });
+
+test('Generate email with prefix', (t) => {
+  // avoid http error 429
+  setTimeout(() => {
+    generateEmail(5, 'prefix')
+      .then((email) => {
+        const name = email.slice(0, email.indexOf('@'));
+        const prefix = name.slice(0, 6);
+
+        t.equal(name.length, 12, 'email name is correct');
+        t.equal(prefix, 'prefix', 'prefix is correct');
+
+        t.end();
+      });
+  }, 700);
+});
+
+test('Generate email without prefix', (t) => {
+  // avoid http error 429
+  setTimeout(() => {
+    generateEmail(5)
+      .then((email) => {
+        const name = email.slice(0, email.indexOf('@'));
+
+        t.equal(name.length, 5, 'email name is correct');
+
+        t.end();
+      });
+  }, 700);
+});


### PR DESCRIPTION
Old random method return inccorect values:

Math.random().toString(36).substring(15) // ""  
Math.random().toString(36).substring(8) // "57slj" 

I changed the method that would return the correct value.

I add new optional arg - prefix, in case when you need a specific name:

getRandomEmail(['@example.com'], 10, 'organization') // "organization-lyql2bla1u@example.com"
